### PR TITLE
Minor release: Added a feature for shell scoping

### DIFF
--- a/DRUN_V2_SPECIFICATION.md
+++ b/DRUN_V2_SPECIFICATION.md
@@ -3145,6 +3145,7 @@ drun v2 supports both single-line and multiline shell command execution with con
 ```
 # Execute and stream output
 run "echo 'Hello World'"
+run "go run ./cmd/pog" attached
 exec "date +%Y-%m-%d"
 shell "pwd"
 
@@ -3201,6 +3202,14 @@ exec:
 run "echo hello"  # Executes: /bin/sh -c "echo hello"
 ```
 
+**Attached single-line `run` commands**: Stay connected to the current terminal for interactive programs
+```
+run "go run ./cmd/pog" attached
+run in service $servicename "npm run dev" attached
+```
+
+Use `attached` only with single-line `run` statements when the command needs stdin or terminal behavior. Plain `run` remains non-interactive by default.
+
 **Multiline commands**: Execute as a single shell session
 ```
 run:
@@ -3218,6 +3227,7 @@ When services are declared in the program, shell commands can target a service's
 task "inspect-service" given $servicename defaults to "some-service":
     run in service $servicename "ls -a"
     run in service $servicename "cat Dockerfile"
+    run in service $servicename "npm run dev" attached
 ```
 
 The runtime resolves the service name (from literals, task parameters, or captured variables), validates that the service exists, and executes the command inside the service directory. If no services are defined, or the service name cannot be resolved, execution fails fast with an explanatory error.

--- a/DRUN_V2_SPECIFICATION.md
+++ b/DRUN_V2_SPECIFICATION.md
@@ -3145,7 +3145,7 @@ drun v2 supports both single-line and multiline shell command execution with con
 ```
 # Execute and stream output
 run "echo 'Hello World'"
-run "go run ./cmd/pog" attached
+run "command" attached
 exec "date +%Y-%m-%d"
 shell "pwd"
 
@@ -3204,7 +3204,7 @@ run "echo hello"  # Executes: /bin/sh -c "echo hello"
 
 **Attached single-line `run` commands**: Stay connected to the current terminal for interactive programs
 ```
-run "go run ./cmd/pog" attached
+run "command" attached
 run in service $servicename "npm run dev" attached
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,20 @@ xdrun deploy environment=production version=v1.2.3
 - `key=value` task parameters with CLI flags kept separate.
 - Built-in validation, defaults, and control flow.
 - Dry-run support for inspecting execution.
+- Optional `run ... attached` mode for REPL-style commands that need stdin and a terminal.
 - Reusable task files and examples for common workflows.
 - Orchestration support for multi-service projects.
+
+## Interactive Commands
+
+Use `attached` when a `run` command must stay connected to your terminal, such as REPLs or tools that prompt for input:
+
+```drun
+task "repl":
+  run "go run ./cmd/pog" attached
+```
+
+Plain `run "command"` remains non-interactive and is still the default for ordinary automation steps.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Use `attached` when a `run` command must stay connected to your terminal, such a
 
 ```drun
 task "repl":
-  run "go run ./cmd/pog" attached
+  run "go run command" attached
 ```
 
 Plain `run "command"` remains non-interactive and is still the default for ordinary automation steps.

--- a/examples/README.md
+++ b/examples/README.md
@@ -262,7 +262,7 @@ depends on lint, test, scan        # Parallel dependencies
 let name be "value"                 # Immutable binding
 set counter to 0                    # Mutable variable
 capture from shell "command" as $variable       # Capture command output
-run "go run ./cmd/pog" attached     # Keep stdin attached for REPL-like commands
+run "command" attached     # Keep stdin attached for REPL-like commands
 
 # Conditional assignment
 let config be:

--- a/examples/README.md
+++ b/examples/README.md
@@ -262,6 +262,7 @@ depends on lint, test, scan        # Parallel dependencies
 let name be "value"                 # Immutable binding
 set counter to 0                    # Mutable variable
 capture from shell "command" as $variable       # Capture command output
+run "go run ./cmd/pog" attached     # Keep stdin attached for REPL-like commands
 
 # Conditional assignment
 let config be:

--- a/internal/ast/ast_shell.go
+++ b/internal/ast/ast_shell.go
@@ -13,6 +13,7 @@ type ShellStatement struct {
 	Command              string
 	Commands             []string
 	CaptureVar           string
+	Attached             bool
 	StreamOutput         bool
 	IsMultiline          bool
 	ServiceScoped        bool
@@ -55,6 +56,9 @@ func (ss *ShellStatement) String() string {
 
 	if ss.CaptureVar != "" {
 		return fmt.Sprintf("%s \"%s\" as %s", prefix, ss.Command, ss.CaptureVar)
+	}
+	if ss.Attached {
+		return fmt.Sprintf("%s \"%s\" attached", prefix, ss.Command)
 	}
 	return fmt.Sprintf("%s \"%s\"", prefix, ss.Command)
 }

--- a/internal/domain/statement/converter.go
+++ b/internal/domain/statement/converter.go
@@ -23,6 +23,7 @@ func FromAST(astStmt ast.Statement) (Statement, error) {
 			Command:              s.Command,
 			Commands:             s.Commands,
 			CaptureVar:           s.CaptureVar,
+			Attached:             s.Attached,
 			StreamOutput:         s.StreamOutput,
 			IsMultiline:          s.IsMultiline,
 			ServiceScoped:        s.ServiceScoped,

--- a/internal/domain/statement/converter_test.go
+++ b/internal/domain/statement/converter_test.go
@@ -43,6 +43,7 @@ func TestFromAST_Shell(t *testing.T) {
 		Action:     "run",
 		Command:    "echo hello",
 		CaptureVar: "output",
+		Attached:   true,
 	}
 
 	domainStmt, err := FromAST(astShell)
@@ -63,6 +64,9 @@ func TestFromAST_Shell(t *testing.T) {
 	}
 	if shell.CaptureVar != "output" {
 		t.Errorf("CaptureVar = %v, want output", shell.CaptureVar)
+	}
+	if !shell.Attached {
+		t.Error("Attached should be true")
 	}
 }
 

--- a/internal/domain/statement/statement.go
+++ b/internal/domain/statement/statement.go
@@ -51,6 +51,7 @@ type Shell struct {
 	Command              string
 	Commands             []string
 	CaptureVar           string
+	Attached             bool
 	StreamOutput         bool
 	IsMultiline          bool
 	ServiceScoped        bool

--- a/internal/engine/helpers_utilities.go
+++ b/internal/engine/helpers_utilities.go
@@ -218,8 +218,9 @@ func (e *Engine) executeSingleLineShell(shellStmt *statement.Shell, ctx *Executi
 
 	// Configure shell options based on the action type and platform configuration
 	opts := e.getPlatformShellConfig(ctx)
-	opts.CaptureOutput = true
-	opts.StreamOutput = shellStmt.StreamOutput
+	opts.Attached = shellStmt.Attached
+	opts.CaptureOutput = !shellStmt.Attached
+	opts.StreamOutput = shellStmt.StreamOutput || shellStmt.Attached
 	opts.Output = e.output
 	if svcCtx != nil {
 		opts.WorkingDir = svcCtx.Path
@@ -232,9 +233,9 @@ func (e *Engine) executeSingleLineShell(shellStmt *statement.Shell, ctx *Executi
 		switch shellStmt.Action {
 		case "run":
 			if svcCtx != nil {
-				_, _ = fmt.Fprintf(e.output, "🏃 Running in service '%s': %s\n", svcCtx.Name, interpolatedCommand)
+				_, _ = fmt.Fprintf(e.output, "🏃 Running in service '%s'%s: %s\n", svcCtx.Name, attachedLabel(shellStmt.Attached), interpolatedCommand)
 			} else {
-				_, _ = fmt.Fprintf(e.output, "🏃 Running: %s\n", interpolatedCommand)
+				_, _ = fmt.Fprintf(e.output, "🏃 Running%s: %s\n", attachedLabel(shellStmt.Attached), interpolatedCommand)
 			}
 		case "exec":
 			_, _ = fmt.Fprintf(e.output, "⚡ Executing: %s\n", interpolatedCommand)
@@ -270,4 +271,11 @@ func (e *Engine) executeSingleLineShell(shellStmt *statement.Shell, ctx *Executi
 	}
 
 	return nil
+}
+
+func attachedLabel(attached bool) string {
+	if attached {
+		return " attached"
+	}
+	return ""
 }

--- a/internal/parser/README.md
+++ b/internal/parser/README.md
@@ -88,7 +88,7 @@ Action statements and task calls:
 
 #### `parser_shell.go` - 175 lines
 Shell command execution:
-- **Shell statements** (`run "command"`)
+- **Shell statements** (`run "command"`, `run "command" attached`)
 - **Multiline shell commands**
 - **Command capture** (`capture $var from command`)
 
@@ -195,4 +195,3 @@ func (p *Parser) parseTaskStatement() *ast.TaskStatement {
 - Consider extracting common patterns into shared helpers
 - Add inline documentation for complex parsing logic
 - Create parser benchmarks for performance testing
-

--- a/internal/parser/parser_shell.go
+++ b/internal/parser/parser_shell.go
@@ -60,6 +60,14 @@ func (p *Parser) parseShellStatement() *ast.ShellStatement {
 	p.nextToken() // consume STRING
 
 	stmt.Command = p.curToken.Literal
+	if p.peekToken.Type == lexer.IDENT && p.peekToken.Literal == "attached" {
+		if stmt.Action != "run" {
+			p.addError("attached modifier is only supported for run statements")
+			return nil
+		}
+		p.nextToken() // consume attached
+		stmt.Attached = true
+	}
 
 	// Set streaming behavior based on action type
 	switch stmt.Action {

--- a/internal/parser/shell_test.go
+++ b/internal/parser/shell_test.go
@@ -102,12 +102,14 @@ func TestParser_ShellStatementTypes(t *testing.T) {
 		expectedAction string
 		expectedCmd    string
 		expectedVar    string
+		attached       bool
 		streamOutput   bool
 	}{
-		{`run "echo hello"`, "run", "echo hello", "", true},
-		{`exec "date"`, "exec", "date", "", true},
-		{`shell "pwd"`, "shell", "pwd", "", true},
-		{`capture from shell "whoami" as $user`, "capture", "whoami", "user", false},
+		{`run "echo hello"`, "run", "echo hello", "", false, true},
+		{`run "echo hello" attached`, "run", "echo hello", "", true, true},
+		{`exec "date"`, "exec", "date", "", false, true},
+		{`shell "pwd"`, "shell", "pwd", "", false, true},
+		{`capture from shell "whoami" as $user`, "capture", "whoami", "user", false, false},
 	}
 
 	for _, test := range tests {
@@ -170,6 +172,9 @@ task "test":
 			if shellStmt.StreamOutput != test.streamOutput {
 				t.Errorf("Expected stream output %v, got %v", test.streamOutput, shellStmt.StreamOutput)
 			}
+			if shellStmt.Attached != test.attached {
+				t.Errorf("Expected attached %v, got %v", test.attached, shellStmt.Attached)
+			}
 		}
 	}
 }
@@ -214,6 +219,9 @@ task "svc":
 	if !shellStmt.ServiceNameIsLiteral {
 		t.Errorf("expected literal service name")
 	}
+	if shellStmt.Attached {
+		t.Errorf("expected non-attached run statement")
+	}
 }
 
 func TestParser_RunInServiceWithVariable(t *testing.T) {
@@ -247,5 +255,47 @@ task "svc":
 
 	if shellStmt.ServiceNameIsLiteral {
 		t.Errorf("expected non-literal service name")
+	}
+}
+
+func TestParser_RunInServiceAttached(t *testing.T) {
+	input := `version: 2.0
+
+task "svc":
+  run in service "api" "npm run dev" attached
+`
+
+	l := lexer.NewLexer(input)
+	p := NewParser(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) != 0 {
+		t.Fatalf("Parser errors: %v", p.Errors())
+	}
+
+	task := program.Tasks[0]
+	shellStmt, ok := task.Body[0].(*ast.ShellStatement)
+	if !ok {
+		t.Fatalf("expected ShellStatement, got %T", task.Body[0])
+	}
+
+	if !shellStmt.Attached {
+		t.Fatalf("expected attached run statement")
+	}
+}
+
+func TestParser_AttachedRejectedForExec(t *testing.T) {
+	input := `version: 2.0
+
+task "svc":
+  exec "date" attached
+`
+
+	l := lexer.NewLexer(input)
+	p := NewParser(l)
+	_ = p.ParseProgram()
+
+	if len(p.Errors()) == 0 {
+		t.Fatalf("expected parser error for exec attached")
 	}
 }

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -34,6 +34,7 @@ type Options struct {
 	Output        io.Writer         // Where to stream output (if StreamOutput is true)
 	Shell         string            // Shell to use (default: /bin/sh)
 	IgnoreErrors  bool              // Whether to ignore non-zero exit codes
+	Attached      bool              // Whether to keep stdin attached and allocate a TTY when possible
 }
 
 // DefaultOptions returns sensible default options
@@ -58,6 +59,7 @@ func DefaultOptions() *Options {
 		Output:        os.Stdout,
 		Shell:         defaultShell,
 		IgnoreErrors:  false,
+		Attached:      false,
 	}
 }
 
@@ -81,11 +83,15 @@ func Execute(command string, opts *Options) (*Result, error) {
 	}
 
 	// Create the command
-	cmd := exec.CommandContext(ctx, opts.Shell, "-c", command)
+	cmd := buildCommand(ctx, command, opts)
 
 	// Explicitly set stdin to nil to prevent commands from hanging waiting for input
-	// This is important for non-interactive command execution
-	cmd.Stdin = nil
+	// This is important for non-interactive command execution.
+	if opts.Attached {
+		cmd.Stdin = os.Stdin
+	} else {
+		cmd.Stdin = nil
+	}
 
 	// Set working directory
 	if opts.WorkingDir != "" {
@@ -196,6 +202,25 @@ func Execute(command string, opts *Options) (*Result, error) {
 	}
 
 	return result, nil
+}
+
+func buildCommand(ctx context.Context, command string, opts *Options) *exec.Cmd {
+	if opts.Attached {
+		return createTTYCommand(ctx, command, opts.Shell)
+	}
+
+	return exec.CommandContext(ctx, opts.Shell, "-c", command)
+}
+
+func createTTYCommand(ctx context.Context, command, shellPath string) *exec.Cmd {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.CommandContext(ctx, "script", "-q", "/dev/null", shellPath, "-c", command)
+	case "linux":
+		return exec.CommandContext(ctx, "script", "-q", "-e", "-c", fmt.Sprintf("%s -c %q", shellPath, command), "/dev/null")
+	default:
+		return exec.CommandContext(ctx, shellPath, "-c", command)
+	}
 }
 
 // ExecuteSimple runs a command with default options and returns just the output

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"runtime"
 	"strings"
@@ -246,6 +247,38 @@ func TestDefaultOptions(t *testing.T) {
 
 	if opts.StreamOutput {
 		t.Errorf("Expected StreamOutput to be false by default")
+	}
+
+	if opts.Attached {
+		t.Errorf("Expected Attached to be false by default")
+	}
+}
+
+func TestBuildCommand_AttachedUsesTTYOnUnix(t *testing.T) {
+	opts := DefaultOptions()
+	opts.Attached = true
+
+	cmd := buildCommand(context.Background(), "echo test", opts)
+
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		if !strings.HasSuffix(cmd.Path, "/script") && cmd.Path != "script" {
+			t.Fatalf("Expected attached mode to use script, got %q", cmd.Path)
+		}
+		return
+	}
+
+	if cmd.Path != opts.Shell {
+		t.Fatalf("Expected fallback shell %q, got %q", opts.Shell, cmd.Path)
+	}
+}
+
+func TestBuildCommand_DefaultUsesShell(t *testing.T) {
+	opts := DefaultOptions()
+
+	cmd := buildCommand(context.Background(), "echo test", opts)
+
+	if cmd.Path != opts.Shell {
+		t.Fatalf("Expected shell %q, got %q", opts.Shell, cmd.Path)
 	}
 }
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -267,7 +268,7 @@ func TestBuildCommand_AttachedUsesTTYOnUnix(t *testing.T) {
 		return
 	}
 
-	if cmd.Path != opts.Shell {
+	if filepath.Base(cmd.Path) != filepath.Base(opts.Shell) {
 		t.Fatalf("Expected fallback shell %q, got %q", opts.Shell, cmd.Path)
 	}
 }
@@ -277,7 +278,7 @@ func TestBuildCommand_DefaultUsesShell(t *testing.T) {
 
 	cmd := buildCommand(context.Background(), "echo test", opts)
 
-	if cmd.Path != opts.Shell {
+	if filepath.Base(cmd.Path) != filepath.Base(opts.Shell) {
 		t.Fatalf("Expected shell %q, got %q", opts.Shell, cmd.Path)
 	}
 }


### PR DESCRIPTION
This is version 2.16.0

- Added the attached keyword

When using shell, I noticed our intitial implementation didn't allow us to use shell in interactive mode.
I've pondered other fluent forms of stating that like

```drun
run "command" in iterative mode
```

But it's too verbose. In the end I chose attached.

```drun
run "command" attached
```

It is clear, simple, communicates it well.

I've tested the whole CI locally and it works. Let me know if you want to pack this release with anything else.