### PR TITLE
Feature: Task Execution mode

### DIFF
--- a/.drun/spec.drun
+++ b/.drun/spec.drun
@@ -14,27 +14,28 @@ task "default" means "Welcome to drun v2":
 	info "Welcome to drun v2! 🚀"
 
 task "test" means "Runs unit tests":
-	info "Running PHPUnit (just kidding)"
+	info "Running PHPUnit"
 	run "go test ./..."
 
 task "lint" means "Runs the Golang CI Linter":
-	info "Running PHPCS (just kidding)"
+	info "Running PHPCS"
 	run "golangci-lint run ./..."
 
-task "sec-strict" means "Security tests":
-	info "Running gosec..."
+task "sec" means "Security checks (high)":
+	info "Running gosec"
 	run "gosec -severity high -confidence medium ./..."
 
-task "sec" means "Security checks (high)":
-	info "Running gosec (setting to high only)"
-	run "gosec -severity high ./..."
+task "fuzz" means "Runs the fuzzers":
+	given $iterations defaults to 50
+	step "Executing semantic fuzz tests against example-based inputs\nIterations: {$iterations}"
+	run "./scripts/fuzz-examples.sh {$iterations}"
 
 task "install" means "Install xdrun with build info":
 	info "Installing xdrun with embedded build date/time..."
 	run "go install -ldflags=\"-X 'main.date=$(date +'%d/%m/%Y %H:%M:%S') (dev build)'\" ./cmd/xdrun"
 	success "xdrun installed to $GOPATH/bin"
 
-task "ci" means "Runs the whole CI pipeline":
+task "ci" mode "ci" means "Runs the whole CI pipeline":
 	info "Executing the local CI pipeline..."
 	step "Linter"
 	call task lint
@@ -44,3 +45,6 @@ task "ci" means "Runs the whole CI pipeline":
 	run "./scripts/test-regressions.sh"
 	step "Security checks"
 	call task sec
+	info "Semantic fuzzing"
+	call task fuzz with iterations=50
+	success "CI executed successfully end-to-end"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,11 @@ jobs:
         echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
         eval "$(brew shellenv)"
 
-        # Remove unrelated third-party taps that trigger trust warnings on hosted runners.
+        # Remove unrelated third-party taps preinstalled on hosted runners.
+        # Homebrew 6 requires explicit trust for non-official taps during update/install.
         brew untap aws/tap 2>/dev/null || true
         brew untap azure/bicep 2>/dev/null || true
+        brew untap hashicorp/tap 2>/dev/null || true
 
         brew update
         brew install upx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,32 @@ jobs:
     - name: Run tests
       run: ./scripts/test-ci.sh
 
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: 1.26
+        cache: true
+        cache-dependency-path: go.sum
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run semantic fuzzing
+      run: ./scripts/fuzz-examples.sh 50
+
   # Build job for cross-platform binaries
   build:
     name: Build
     runs-on: ${{ matrix.runner }}
-    needs: [lint, test]
+    needs: [lint, test, fuzz]
     strategy:
       matrix:
         include:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -519,6 +519,9 @@ When adding any new feature:
 3. **Test Domain Logic**: Unit tests without dependencies
 4. **Integrate with Engine**: Orchestrate domain operations
 5. **Expose via CLI**: User-facing interface
+6. **Update the Language Spec**: If syntax, semantics, or examples changed, update [DRUN_V2_SPECIFICATION.md](./DRUN_V2_SPECIFICATION.md) in the same change
+7. **Dogfood the Workflow**: If the feature affects project automation, update [.drun/spec.drun](./.drun/spec.drun)
+8. **Finish with Full Validation**: Run targeted tests while iterating, then finish with `xdrun ci`
 
 This keeps your codebase clean, testable, and maintainable! 🎯
 
@@ -538,7 +541,16 @@ go test -cover ./...
 
 # Run examples (regression tests)
 ./scripts/test.sh
+
+# Run local semantic fuzzing from the drun spec
+xdrun fuzz iterations=100
 ```
+
+Fuzz result labels:
+
+- `PASS` means the mutated `.drun` file parsed successfully and its first discovered task also completed `--dry-run` validation.
+- `SOFT` means the mutated file parsed successfully, but the harness could not find a first task it could dry-run with the built-in parameter guesses. This is informational, not a crash.
+- `MISS` means the mutated file was rejected by the parser. This is expected sometimes because the generator intentionally introduces some malformed but drun-like input.
 
 ### Test Organization
 

--- a/DRUN_V2_SPECIFICATION.md
+++ b/DRUN_V2_SPECIFICATION.md
@@ -129,7 +129,7 @@ project_setting = "set" identifier "to" expression
                 | shell_config ;
 
 (* Task definition *)
-task_definition = "task" string_literal [ "means" string_literal ] ":"
+task_definition = "task" string_literal [ "mode" string_literal ] [ "means" string_literal ] ":"
                  { task_property }
                  statement_block ;
 
@@ -214,7 +214,7 @@ task_call_statement = "call" "task" string_literal [ "with" parameter_list ] ;
 
 parameter_list = parameter_assignment { parameter_assignment } ;
 
-parameter_assignment = identifier "=" string_literal ;
+parameter_assignment = identifier "=" ( string_literal | number ) ;
 
 (* Conditions *)
 condition = logical_expression ;
@@ -869,7 +869,15 @@ call task "my-special-task"
 ```
 call task "task_name" with param1="value1" param2="value2"
 call task task_name with param1="value1" param2="value2"  # Unquoted task name
+call task fuzz with iterations=100                         # Numeric literals are allowed bare
 ```
+
+Task call parameter values currently support:
+
+- Quoted strings: `name="Alice"`
+- Bare numbers: `iterations=100`, `replicas=3`
+
+Bare numeric literals are passed through as string values to the called task, which keeps task-call syntax aligned with normal drun parameter handling while avoiding unnecessary quotes for numeric inputs.
 
 #### Examples
 
@@ -898,13 +906,14 @@ task "full-pipeline":
   call task "run-tests" with test_type="unit"
   call task "run-tests" with test_type="integration"
   call task "build-application" with target="production"
+  call task fuzz with iterations=100
   
   success "Full pipeline completed successfully!"
 ```
 
 #### Key Features
 
-- **Parameter Passing**: Pass parameters to called tasks using `with param="value"` syntax
+- **Parameter Passing**: Pass parameters to called tasks using `with param="value"` or `with param=123` syntax
 - **Variable Sharing**: Variables set in called tasks are available in the calling task
 - **Error Handling**: If a called task fails, the calling task fails with an appropriate error message
 - **Execution Flow**: Called tasks execute completely before returning control to the calling task
@@ -3158,6 +3167,38 @@ capture from shell "git rev-parse --short HEAD" as $commit_hash
 capture from shell "whoami" as $username
 ```
 
+#### Task Modes
+
+Tasks can opt into execution modes directly in the declaration:
+
+```drun
+task "ci" mode "ci" means "Run noisy checks quietly":
+  step "Lint"
+  run "golangci-lint run ./..."
+  step "Security"
+  run "gosec ./..."
+```
+
+Currently supported modes:
+
+- `normal` is the standard execution behavior. This is the implicit default when a task does not declare a mode. Shell command output streams normally as commands run.
+- `ci` buffers shell command output for the task and only prints the buffered stdout/stderr if a command fails. Action statements like `step`, `info`, and `success` still print normally.
+
+`ci` is the only mode currently declared inside task definitions. Use the normal default behavior by omitting the `mode` clause entirely.
+
+**Runtime Override**
+
+`xdrun` can override the execution mode for a single invocation:
+
+```bash
+xdrun ci --task-mode=normal
+xdrun build --task-mode=ci
+```
+
+- `--task-mode=normal` forces normal streaming behavior even when the task declaration uses `mode "ci"`.
+- `--task-mode=ci` applies CI-style buffering for the invoked task and any called tasks during that run.
+- Supported runtime override values are `normal` and `ci`.
+
 #### Multiline Commands (Block Syntax)
 
 For complex shell operations, use the block syntax with natural indentation:
@@ -3896,6 +3937,18 @@ success "Deployment completed successfully"
   ┌────────────────────────────────┐
   │ Starting deployment process    │
   └────────────────────────────────┘
+  ```
+  Multiline strings are supported and each line is rendered inside the same box:
+  ```
+  step "Executing semantic fuzz tests against example-based inputs
+  Iterations: 50"
+  ```
+  Produces:
+  ```
+  ┌─────────────────────────────────────────────────────────────┐
+  │ Executing semantic fuzz tests against example-based inputs │
+  │ Iterations: 50                                             │
+  └─────────────────────────────────────────────────────────────┘
   ```
 - `info` - Displays with ℹ️ emoji prefix: `ℹ️  Configuration loaded successfully`
 - `warn` - Displays with ⚠️ emoji prefix: `⚠️  Using default configuration`
@@ -5686,6 +5739,15 @@ func (ic *IncrementalCompiler) CompileChanged(changes []Change) error {
 ---
 
 This specification provides a comprehensive foundation for implementing drun v2's semantic language. The design prioritizes readability and maintainability while leveraging the existing drun infrastructure for performance and compatibility.
+
+### Implementation And Validation Contract
+
+When drun adds or changes language behavior, contributors should treat the following as part of the feature:
+
+- Update this specification in the same change whenever syntax, semantics, or normative examples change.
+- Add focused parser, domain, and engine tests that cover the new behavior, not just manual verification.
+- Update `.drun/spec.drun` when the feature affects repository-local workflows so the project continues to exercise its own language.
+- Finish validation with `xdrun ci`, which is the project-level end-to-end check for the current local workflow.
 
 
 ## Pattern Macro System

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ xdrun deploy environment=production version=v1.2.3
 - `key=value` task parameters with CLI flags kept separate.
 - Built-in validation, defaults, and control flow.
 - Dry-run support for inspecting execution.
+- Task modes, including CI buffering and one-run overrides via `--task-mode`.
 - Optional `run ... attached` mode for REPL-style commands that need stdin and a terminal.
 - Reusable task files and examples for common workflows.
 - Orchestration support for multi-service projects.

--- a/cmd/xdrun/app/cli.go
+++ b/cmd/xdrun/app/cli.go
@@ -25,8 +25,10 @@ type App struct {
 	listTasks          bool
 	dryRun             bool
 	verbose            bool
+	taskMode           string
 	showVersion        bool
 	initConfig         bool
+	initMinimalConfig  bool
 	saveAsDefault      bool
 	setWorkspace       string
 	selfUpdate         bool
@@ -69,6 +71,7 @@ Examples:
   xdrun build --env=production   # Run 'build' task with environment
   xdrun --list                   # List all available tasks
   xdrun --init                   # Create a new .drun file
+  xdrun --init-minimal           # Create a minimal .drun file
   xdrun --debug --tokens         # Debug lexer tokens
   xdrun --debug --ast            # Debug AST structure
   xdrun --debug --full           # Full debug output
@@ -158,10 +161,12 @@ func (a *App) setupFlags() {
 	flags.BoolVarP(&a.listTasks, "list", "l", false, "[xdrun CLI cmd] List available tasks")
 	flags.BoolVar(&a.dryRun, "dry-run", false, "[xdrun CLI cmd] Show what would be executed without running")
 	flags.BoolVarP(&a.verbose, "verbose", "v", false, "[xdrun CLI cmd] Show detailed execution information")
+	flags.StringVar(&a.taskMode, "task-mode", "", "[xdrun CLI cmd] Override task execution mode for this run (supported: ci, normal)")
 	flags.BoolVar(&a.noDrunCache, "no-drun-cache", false, "[xdrun CLI cmd] Disable remote include caching (always fetch)")
 	flags.BoolVar(&a.showVersion, "version", false, "[xdrun CLI cmd] Show version information")
 	flags.BoolVar(&a.initConfig, "init", false, "[xdrun CLI cmd] Initialize a new .drun task file")
-	flags.BoolVar(&a.saveAsDefault, "save-as-default", false, "[xdrun CLI cmd] Save custom file name as workspace default (use with --init)")
+	flags.BoolVar(&a.initMinimalConfig, "init-minimal", false, "[xdrun CLI cmd] Initialize a new minimal .drun task file")
+	flags.BoolVar(&a.saveAsDefault, "save-as-default", false, "[xdrun CLI cmd] Save custom file name as workspace default (use with --init or --init-minimal)")
 	flags.StringVar(&a.setWorkspace, "set-workspace", "", "[xdrun CLI cmd] Set workspace default task file location")
 	flags.BoolVar(&a.selfUpdate, "self-update", false, "[xdrun CLI cmd] Check for updates and update xdrun to the latest version")
 	flags.BoolVar(&a.allowUndefinedVars, "allow-undefined-variables", false, "[xdrun CLI cmd] Allow undefined variables in interpolation (default: strict mode)")
@@ -216,7 +221,11 @@ func (a *App) run(cmd *cobra.Command, args []string) error {
 
 	// Handle --init flag
 	if a.initConfig {
-		return InitializeConfig(a.configFile, a.saveAsDefault)
+		return InitializeConfig(a.configFile, a.saveAsDefault, false)
+	}
+
+	if a.initMinimalConfig {
+		return InitializeConfig(a.configFile, a.saveAsDefault, true)
 	}
 
 	// Handle --set-workspace flag
@@ -250,6 +259,7 @@ func (a *App) run(cmd *cobra.Command, args []string) error {
 		a.listTasks,
 		a.dryRun,
 		a.verbose,
+		a.taskMode,
 		a.allowUndefinedVars,
 		a.noDrunCache,
 		args,

--- a/cmd/xdrun/app/config.go
+++ b/cmd/xdrun/app/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -172,7 +173,7 @@ func loadWorkspaceConfig() (*WorkspaceConfig, error) {
 }
 
 // initializeConfig creates a new drun configuration file
-func InitializeConfig(filename string, saveAsDefault bool) error {
+func InitializeConfig(filename string, saveAsDefault bool, minimal bool) error {
 	// Determine the target filename
 	targetFile := ".drun/spec.drun"
 	if filename != "" {
@@ -197,7 +198,7 @@ func InitializeConfig(filename string, saveAsDefault bool) error {
 	}
 
 	// Generate starter configuration
-	config := generateStarterConfig()
+	config := generateStarterConfig(minimal)
 
 	// Write the file
 	if err := os.WriteFile(targetFile, []byte(config), 0600); err != nil {
@@ -271,50 +272,31 @@ func SetWorkspaceDefault(filename string) error {
 }
 
 // generateStarterConfig creates a starter drun v2 configuration
-func generateStarterConfig() string {
-	return `# drun (do-run) CLI is a fast, semantic task runner with 
+func generateStarterConfig(minimal bool) string {
+	projectName := inferProjectNameFromWorkingDir()
+
+	if minimal {
+		return `# drun (do-run) CLI is a fast, semantic task runner with 
 # its own powerful automation language. Effortless tasks, serious speed.
-# Learn more at https://github.com/phillarmonic/drun/v2
+# Learn more at https://github.com/phillarmonic/drun
 
 version: 2.0
 
-project "my-app" version "1.0":
-	/* Cross-platform shell configuration with sensible defaults
-	 These are all default values, you can remove them if you don't intend to change it. */
-
-	shell config:
-		darwin:
-			executable: "/bin/zsh"
-			args:
-				- "-l"
-				- "-i"
-			environment:
-				TERM: "xterm-256color"
-				SHELL_SESSION_HISTORY: "0"
-		
-		linux:
-			executable: "/bin/bash"
-			args:
-				- "--login"
-				- "--interactive"
-			environment:
-				TERM: "xterm-256color"
-				HISTCONTROL: "ignoredups"
-		
-		windows:
-			executable: "powershell.exe"
-			args:
-				- "-NoProfile"
-				- "-ExecutionPolicy"
-				- "Bypass"
-			environment:
-				PSModulePath: ""
-
-task "default" means "Welcome to drun v2":
-	echo "Starting up..."
+project "` + projectName + `" version "1.0":
+task "default" means "Welcome":
 	info "Welcome to drun v2! 🚀"
-	step "This is your starter task file"
-	success "Ready to build amazing automation!"
+`
+	}
+
+	return `# drun (do-run) CLI is a fast, semantic task runner with 
+# its own powerful automation language. Effortless tasks, serious speed.
+# Learn more at https://github.com/phillarmonic/drun
+
+version: 2.0
+
+project "` + projectName + `" version "1.0":
+task "default" means "Welcome":
+	info "Welcome to drun v2! 🚀"
 
 task "hello" means "Say hello":
 	info "Hello from the semantic task runner!"
@@ -336,4 +318,18 @@ task "deploy" means "Deploy application":
 	info "Add your deployment commands here"
 	success "Deployment to {$environment} completed!"
 `
+}
+
+func inferProjectNameFromWorkingDir() string {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "my-app"
+	}
+
+	projectName := strings.TrimSpace(filepath.Base(filepath.Clean(workingDir)))
+	if projectName == "" || projectName == "." || projectName == string(filepath.Separator) {
+		return "my-app"
+	}
+
+	return projectName
 }

--- a/cmd/xdrun/app/config_test.go
+++ b/cmd/xdrun/app/config_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/phillarmonic/drun/v2/internal/lexer"
+	"github.com/phillarmonic/drun/v2/internal/parser"
+)
+
+func TestInferProjectNameFromWorkingDirUsesFolderName(t *testing.T) {
+	tempRoot := t.TempDir()
+	projectDir := filepath.Join(tempRoot, "sample-service")
+	if err := os.Mkdir(projectDir, 0750); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("Chdir() restore error = %v", chdirErr)
+		}
+	})
+
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	if got := inferProjectNameFromWorkingDir(); got != "sample-service" {
+		t.Fatalf("inferProjectNameFromWorkingDir() = %q, want %q", got, "sample-service")
+	}
+}
+
+func TestGenerateStarterConfigUsesWorkingDirectoryName(t *testing.T) {
+	tempRoot := t.TempDir()
+	projectDir := filepath.Join(tempRoot, "starter-app")
+	if err := os.Mkdir(projectDir, 0750); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("Chdir() restore error = %v", chdirErr)
+		}
+	})
+
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	config := generateStarterConfig(false)
+	if !strings.Contains(config, `project "starter-app" version "1.0":`) {
+		t.Fatalf("generateStarterConfig() did not embed working directory name:\n%s", config)
+	}
+
+	assertGeneratedConfigParses(t, config)
+}
+
+func TestGenerateStarterConfigMinimalContainsOnlyWelcomeTask(t *testing.T) {
+	tempRoot := t.TempDir()
+	projectDir := filepath.Join(tempRoot, "minimal-app")
+	if err := os.Mkdir(projectDir, 0750); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("Chdir() restore error = %v", chdirErr)
+		}
+	})
+
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	config := generateStarterConfig(true)
+	if !strings.Contains(config, `project "minimal-app" version "1.0":`) {
+		t.Fatalf("generateStarterConfig(true) did not embed working directory name:\n%s", config)
+	}
+	if !strings.Contains(config, `task "default" means "Welcome":`) {
+		t.Fatalf("generateStarterConfig(true) did not include default welcome task:\n%s", config)
+	}
+	if strings.Contains(config, `task "hello" means "Say hello":`) {
+		t.Fatalf("generateStarterConfig(true) should not include extra tasks:\n%s", config)
+	}
+
+	assertGeneratedConfigParses(t, config)
+}
+
+func assertGeneratedConfigParses(t *testing.T, config string) {
+	t.Helper()
+
+	l := lexer.NewLexer(config)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+
+	if program == nil {
+		t.Fatal("generated config did not parse")
+	}
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("generated config parse errors: %v\n%s", errs, config)
+	}
+}

--- a/cmd/xdrun/app/runner.go
+++ b/cmd/xdrun/app/runner.go
@@ -20,10 +20,16 @@ func ExecuteTask(
 	listTasks bool,
 	dryRun bool,
 	verbose bool,
+	taskModeOverride string,
 	allowUndefinedVars bool,
 	noDrunCache bool,
 	args []string,
 ) error {
+	taskModeOverride, err := normalizeRuntimeTaskMode(taskModeOverride)
+	if err != nil {
+		return err
+	}
+
 	// Determine the config file to use
 	actualConfigFile, err := FindConfigFile(configFile)
 	if err != nil {
@@ -73,6 +79,7 @@ func ExecuteTask(
 		engine.WithOutput(os.Stdout),
 		engine.WithDryRun(dryRun),
 		engine.WithVerbose(verbose),
+		engine.WithTaskModeOverride(taskModeOverride),
 		engine.WithSecretsManager(secretsMgr),
 	)
 	eng.SetAllowUndefinedVars(allowUndefinedVars)

--- a/cmd/xdrun/app/stateless.go
+++ b/cmd/xdrun/app/stateless.go
@@ -173,7 +173,7 @@ func AddStatelessDirectory(directory string, createTemplate bool) error {
 		}
 
 		// Generate starter configuration
-		template := generateStarterConfig()
+		template := generateStarterConfig(false)
 		if err := os.WriteFile(configLocation, []byte(template), 0600); err != nil {
 			return fmt.Errorf("failed to create template: %w", err)
 		}

--- a/cmd/xdrun/app/task_mode.go
+++ b/cmd/xdrun/app/task_mode.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+func normalizeRuntimeTaskMode(mode string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(mode))
+	switch normalized {
+	case "", "ci", "normal":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported runtime task mode %q (supported: ci, normal)", mode)
+	}
+}

--- a/cmd/xdrun/app/task_mode_test.go
+++ b/cmd/xdrun/app/task_mode_test.go
@@ -1,0 +1,36 @@
+package app
+
+import "testing"
+
+func TestNormalizeRuntimeTaskMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty means no override", input: "", want: ""},
+		{name: "ci", input: "ci", want: "ci"},
+		{name: "normal", input: "normal", want: "normal"},
+		{name: "mixed case is normalized", input: " NoRmAl ", want: "normal"},
+		{name: "invalid mode fails", input: "verbose", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeRuntimeTaskMode(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeRuntimeTaskMode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/xdrun/app/version.go
+++ b/cmd/xdrun/app/version.go
@@ -32,7 +32,7 @@ func ShowVersion(version, commit, date string) error {
 	fmt.Println("xDrun (eXecute drun) CLI")
 	fmt.Println()
 	fmt.Println("Effortless tasks, serious speed.")
-	fmt.Println("By Phillarmonic Software <https://github.com/phillarmonic/drun/v2>")
+	fmt.Println("By Phillarmonic Software <https://github.com/phillarmonic/drun>")
 	fmt.Println("")
 	fmt.Printf("Version %s\n", version)
 	if commit != "unknown" {

--- a/internal/ast/ast_task.go
+++ b/internal/ast/ast_task.go
@@ -11,6 +11,7 @@ import (
 type TaskStatement struct {
 	Token        lexer.Token
 	Name         string
+	Mode         string
 	Description  string
 	Parameters   []ParameterStatement
 	Dependencies []DependencyGroup
@@ -21,6 +22,9 @@ func (ts *TaskStatement) statementNode() {}
 func (ts *TaskStatement) String() string {
 	var out strings.Builder
 	fmt.Fprintf(&out, "task \"%s\"", ts.Name)
+	if ts.Mode != "" {
+		fmt.Fprintf(&out, " mode \"%s\"", ts.Mode)
+	}
 	if ts.Description != "" {
 		fmt.Fprintf(&out, " means \"%s\"", ts.Description)
 	}

--- a/internal/domain/task/registry_test.go
+++ b/internal/domain/task/registry_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -26,6 +27,19 @@ func TestRegistry_Register(t *testing.T) {
 	err = registry.Register(task1)
 	if err == nil {
 		t.Error("Register() should fail for duplicate task")
+	}
+}
+
+func TestRegistry_RegisterRejectsUnsupportedTaskMode(t *testing.T) {
+	registry := NewRegistry()
+
+	err := registry.Register(&Task{Name: "bad", Mode: "unknown"})
+	if err == nil {
+		t.Fatal("expected unsupported task mode to fail registration")
+	}
+
+	if !strings.Contains(err.Error(), `unsupported task mode "unknown"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/domain/task/task.go
+++ b/internal/domain/task/task.go
@@ -10,6 +10,7 @@ import (
 // Task represents a domain task entity
 type Task struct {
 	Name         string
+	Mode         string
 	Description  string
 	Parameters   []Parameter
 	Dependencies []Dependency
@@ -28,6 +29,7 @@ func NewTask(stmt *ast.TaskStatement, namespace, source string) (*Task, error) {
 
 	task := &Task{
 		Name:        stmt.Name,
+		Mode:        stmt.Mode,
 		Description: stmt.Description,
 		Namespace:   namespace,
 		Source:      source,
@@ -92,6 +94,13 @@ func (t *Task) Validate() error {
 		return &TaskError{
 			Task:    t.Name,
 			Message: "task name cannot be empty",
+		}
+	}
+
+	if t.Mode != "" && t.Mode != "ci" {
+		return &TaskError{
+			Task:    t.Name,
+			Message: fmt.Sprintf("unsupported task mode %q", t.Mode),
 		}
 	}
 

--- a/internal/engine/action_step_test.go
+++ b/internal/engine/action_step_test.go
@@ -1,0 +1,55 @@
+package engine
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStepActionRendersMultilineBox(t *testing.T) {
+	input := `version: 2.0
+
+task "fuzz":
+  given $iterations defaults to 50
+  step "Executing semantic fuzz tests against example-based inputs
+Iterations: {$iterations}"`
+
+	var buf bytes.Buffer
+	if err := ExecuteString(input, "fuzz", &buf); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	expected := "" +
+		"┌────────────────────────────────────────────────────────────┐\n" +
+		"│ Executing semantic fuzz tests against example-based inputs │\n" +
+		"│ Iterations: 50                                             │\n" +
+		"└────────────────────────────────────────────────────────────┘\n"
+
+	if got := buf.String(); got != expected {
+		t.Fatalf("unexpected step box output:\n%s", got)
+	}
+}
+
+func TestStepActionLineBreakFlagsStillWrapMultilineBox(t *testing.T) {
+	input := `version: 2.0
+
+task "fuzz":
+  given $iterations defaults to 50
+  step "Phase 1\nIterations: {$iterations}" add line break before add line break after`
+
+	var buf bytes.Buffer
+	if err := ExecuteString(input, "fuzz", &buf); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	expected := "" +
+		"\n" +
+		"┌────────────────┐\n" +
+		"│ Phase 1        │\n" +
+		"│ Iterations: 50 │\n" +
+		"└────────────────┘\n" +
+		"\n"
+
+	if got := buf.String(); got != expected {
+		t.Fatalf("unexpected step box output with line breaks:\n%s", got)
+	}
+}

--- a/internal/engine/context.go
+++ b/internal/engine/context.go
@@ -15,6 +15,7 @@ type ExecutionContext struct {
 	Project            *ProjectContext         // project-level settings and hooks
 	CurrentFile        string                  // path to the current drun file being executed
 	CurrentTask        string                  // name of the currently executing task
+	CurrentTaskMode    string                  // execution mode of the current task (e.g. "ci" or "normal")
 	CurrentNamespace   string                  // namespace of currently executing task/template (for transitive resolution)
 	Program            *ast.Program            // the AST program being executed
 	WorkingDir         string                  // override working directory for shell commands (empty = use process cwd)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/phillarmonic/drun/v2/internal/ast"
 	"github.com/phillarmonic/drun/v2/internal/builtins"
@@ -38,10 +39,11 @@ type SecretsManager interface {
 
 // Engine executes drun v2 programs directly
 type Engine struct {
-	output       io.Writer
-	dryRun       bool
-	verbose      bool
-	interpolator *interpolation.Interpolator
+	output           io.Writer
+	dryRun           bool
+	verbose          bool
+	taskModeOverride string
+	interpolator     *interpolation.Interpolator
 
 	// Domain layer services
 	taskRegistry   *task.Registry
@@ -91,13 +93,14 @@ func NewEngineWithOptions(opts ...Option) *Engine {
 	interp := interpolation.NewInterpolator()
 
 	e := &Engine{
-		output:         options.Output,
-		dryRun:         options.DryRun,
-		verbose:        options.Verbose,
-		interpolator:   interp,
-		githubFetcher:  githubFetcher,
-		httpsFetcher:   httpsFetcher,
-		drunhubFetcher: drunhubFetcher,
+		output:           options.Output,
+		dryRun:           options.DryRun,
+		verbose:          options.Verbose,
+		taskModeOverride: options.TaskModeOverride,
+		interpolator:     interp,
+		githubFetcher:    githubFetcher,
+		httpsFetcher:     httpsFetcher,
+		drunhubFetcher:   drunhubFetcher,
 
 		// Domain services
 		taskRegistry:   options.TaskRegistry,
@@ -335,6 +338,7 @@ func (e *Engine) ExecuteWithParamsAndFile(program *ast.Program, taskName string,
 
 		// Set current task name for globals access
 		ctx.CurrentTask = currentTaskName
+		ctx.CurrentTaskMode = resolvedTaskMode(taskPlan.Mode, plan.Tasks[plan.TargetTask].Mode, e.taskModeOverride)
 
 		// Save workdir state so changes in this task don't leak to the next
 		savedWorkingDir := ctx.WorkingDir
@@ -749,6 +753,12 @@ func (e *Engine) createProjectContext(project *ast.ProjectStatement, currentFile
 
 // executeTask executes a single task with the given context (AST version for templates)
 func (e *Engine) executeTask(task *ast.TaskStatement, ctx *ExecutionContext) error {
+	prevTaskMode := ctx.CurrentTaskMode
+	ctx.CurrentTaskMode = resolvedTaskMode(task.Mode, prevTaskMode, e.taskModeOverride)
+	defer func() {
+		ctx.CurrentTaskMode = prevTaskMode
+	}()
+
 	if e.dryRun {
 		_, _ = fmt.Fprintf(e.output, "[DRY RUN] Would execute task: %s\n", task.Name)
 		if task.Description != "" {
@@ -886,12 +896,22 @@ func (e *Engine) executeAction(action *statement.Action, ctx *ExecutionContext) 
 			_, _ = fmt.Fprintln(e.output)
 		}
 
-		// Print the box
-		boxWidth := len(interpolatedMessage) + 4
-		topLine := "┌" + strings.Repeat("─", boxWidth-2) + "┐"
-		middleLine := "│ " + interpolatedMessage + " │"
-		bottomLine := "└" + strings.Repeat("─", boxWidth-2) + "┘"
-		_, _ = fmt.Fprintf(e.output, "%s\n%s\n%s\n", topLine, middleLine, bottomLine)
+		// Render each line within a box sized to the longest visible line.
+		lines := strings.Split(interpolatedMessage, "\n")
+		maxWidth := 0
+		for _, line := range lines {
+			if width := utf8.RuneCountInString(line); width > maxWidth {
+				maxWidth = width
+			}
+		}
+
+		horizontal := strings.Repeat("─", maxWidth+2)
+		_, _ = fmt.Fprintf(e.output, "┌%s┐\n", horizontal)
+		for _, line := range lines {
+			padding := maxWidth - utf8.RuneCountInString(line)
+			_, _ = fmt.Fprintf(e.output, "│ %s%s │\n", line, strings.Repeat(" ", padding))
+		}
+		_, _ = fmt.Fprintf(e.output, "└%s┘\n", horizontal)
 
 		// Optional line break after
 		if action.LineBreakAfter {
@@ -990,6 +1010,7 @@ func (e *Engine) executeTaskCall(callStmt *statement.TaskCall, ctx *ExecutionCon
 		Project:          ctx.Project,
 		CurrentFile:      ctx.CurrentFile,
 		CurrentTask:      callStmt.TaskName,
+		CurrentTaskMode:  resolvedTaskMode(targetTask.Mode, ctx.CurrentTaskMode, e.taskModeOverride),
 		CurrentNamespace: taskNamespace, // Set namespace for transitive resolution
 		Program:          ctx.Program,
 	}

--- a/internal/engine/executor_shell.go
+++ b/internal/engine/executor_shell.go
@@ -65,6 +65,9 @@ func (e *Engine) executeMultilineShell(shellStmt *statement.Shell, ctx *Executio
 	opts := e.getPlatformShellConfig(ctx)
 	opts.CaptureOutput = true
 	opts.StreamOutput = shellStmt.StreamOutput
+	if shouldBufferShellOutput(ctx, shellStmt) {
+		opts.StreamOutput = false
+	}
 	opts.Output = e.output
 	if svcCtx != nil {
 		opts.WorkingDir = svcCtx.Path
@@ -98,6 +101,9 @@ func (e *Engine) executeMultilineShell(shellStmt *statement.Shell, ctx *Executio
 	// Execute the script as a single shell session
 	result, err := shell.Execute(script, opts)
 	if err != nil {
+		if shouldBufferShellOutput(ctx, shellStmt) {
+			writeBufferedShellFailure(e.output, result)
+		}
 		_, _ = fmt.Fprintf(e.output, "❌  Multiline command failed: %v\n", err)
 		return err
 	}

--- a/internal/engine/helpers_utilities.go
+++ b/internal/engine/helpers_utilities.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -221,6 +222,9 @@ func (e *Engine) executeSingleLineShell(shellStmt *statement.Shell, ctx *Executi
 	opts.Attached = shellStmt.Attached
 	opts.CaptureOutput = !shellStmt.Attached
 	opts.StreamOutput = shellStmt.StreamOutput || shellStmt.Attached
+	if shouldBufferShellOutput(ctx, shellStmt) {
+		opts.StreamOutput = false
+	}
 	opts.Output = e.output
 	if svcCtx != nil {
 		opts.WorkingDir = svcCtx.Path
@@ -249,6 +253,9 @@ func (e *Engine) executeSingleLineShell(shellStmt *statement.Shell, ctx *Executi
 	// Execute the command
 	result, err := shell.Execute(interpolatedCommand, opts)
 	if err != nil {
+		if shouldBufferShellOutput(ctx, shellStmt) {
+			writeBufferedShellFailure(e.output, result)
+		}
 		_, _ = fmt.Fprintf(e.output, "❌  Command failed: %v\n", err)
 		return err
 	}
@@ -278,4 +285,44 @@ func attachedLabel(attached bool) string {
 		return " attached"
 	}
 	return ""
+}
+
+func shouldBufferShellOutput(ctx *ExecutionContext, shellStmt *statement.Shell) bool {
+	if ctx == nil || shellStmt == nil {
+		return false
+	}
+	if shellStmt.Attached || shellStmt.Action == "capture" {
+		return false
+	}
+	return strings.EqualFold(ctx.CurrentTaskMode, "ci")
+}
+
+func resolvedTaskMode(taskMode, inheritedMode, override string) string {
+	if override != "" {
+		return override
+	}
+	if taskMode != "" {
+		return taskMode
+	}
+	return inheritedMode
+}
+
+func writeBufferedShellFailure(output io.Writer, result *shell.Result) {
+	if output == nil || result == nil {
+		return
+	}
+
+	stdout := strings.TrimSpace(result.Stdout)
+	stderr := strings.TrimSpace(result.Stderr)
+
+	if stdout == "" && stderr == "" {
+		return
+	}
+
+	if stdout != "" {
+		_, _ = fmt.Fprintf(output, "stdout:\n%s\n", stdout)
+	}
+	if stderr != "" {
+		_, _ = fmt.Fprintf(output, "stderr:\n%s\n", stderr)
+	}
 }

--- a/internal/engine/options.go
+++ b/internal/engine/options.go
@@ -34,6 +34,9 @@ type EngineOptions struct {
 	// Verbose mode
 	Verbose bool
 
+	// Runtime task mode override for the invocation
+	TaskModeOverride string
+
 	// Secrets manager
 	SecretsManager SecretsManager
 }
@@ -80,6 +83,13 @@ func WithDryRun(dryRun bool) Option {
 func WithVerbose(verbose bool) Option {
 	return func(o *EngineOptions) {
 		o.Verbose = verbose
+	}
+}
+
+// WithTaskModeOverride sets a runtime task mode override for this invocation.
+func WithTaskModeOverride(mode string) Option {
+	return func(o *EngineOptions) {
+		o.TaskModeOverride = mode
 	}
 }
 

--- a/internal/engine/planner/planner.go
+++ b/internal/engine/planner/planner.go
@@ -20,6 +20,7 @@ type HookPlan struct {
 // TaskPlan represents a single task in the execution plan
 type TaskPlan struct {
 	Name        string
+	Mode        string
 	Description string
 	Namespace   string
 	Source      string
@@ -93,6 +94,7 @@ func (p *Planner) Plan(taskName string, program *ast.Program, projectCtx *Projec
 		// Create TaskPlan from domain task
 		taskPlans[domainTask.Name] = &TaskPlan{
 			Name:        domainTask.Name,
+			Mode:        domainTask.Mode,
 			Description: domainTask.Description,
 			Namespace:   domainTask.Namespace,
 			Source:      domainTask.Source,

--- a/internal/engine/task_call_test.go
+++ b/internal/engine/task_call_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/phillarmonic/drun/v2/internal/lexer"
@@ -96,6 +97,40 @@ task "calculator":
 	}
 }
 
+func TestTaskCallWithNumericParameterLiteral(t *testing.T) {
+	input := `
+version: 2.0
+
+task "fuzz":
+  requires $iterations
+  info "Iterations: {$iterations}"
+
+task "main":
+  call task "fuzz" with iterations=100
+`
+
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("Parser errors: %v", p.Errors())
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngine(&buf)
+
+	err := engine.Execute(program, "main")
+	if err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	output := buf.String()
+	if !contains(output, "Iterations: 100") {
+		t.Errorf("Expected output to contain 'Iterations: 100', got: %s", output)
+	}
+}
+
 func TestTaskCallNotFound(t *testing.T) {
 	input := `
 version: 2.0
@@ -154,6 +189,164 @@ task "main":
 	output := buf.String()
 	if !contains(output, "running action") {
 		t.Errorf("Expected output to contain 'running action', got: %s", output)
+	}
+}
+
+func TestCITaskModeBuffersSuccessfulShellOutput(t *testing.T) {
+	input := `
+version: 2.0
+
+task "ci" mode "ci":
+  info "Starting"
+  run "echo hidden output"
+  success "Done"
+`
+
+	var buf bytes.Buffer
+	if err := ExecuteString(input, "ci", &buf); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Starting") {
+		t.Fatalf("Expected action output to remain visible, got: %s", output)
+	}
+	if strings.Contains(output, "hidden output") {
+		t.Fatalf("Expected successful shell output to stay buffered in ci mode, got: %s", output)
+	}
+	if !strings.Contains(output, "Done") {
+		t.Fatalf("Expected success action to remain visible, got: %s", output)
+	}
+}
+
+func TestCITaskModePrintsBufferedShellOutputOnFailure(t *testing.T) {
+	input := `
+version: 2.0
+
+task "ci" mode "ci":
+  run "echo useful output; echo noisy error >&2; exit 1"
+`
+
+	var buf bytes.Buffer
+	err := ExecuteString(input, "ci", &buf)
+	if err == nil {
+		t.Fatal("Expected ci task to fail")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "stdout:\nuseful output") {
+		t.Fatalf("Expected buffered stdout to be printed on failure, got: %s", output)
+	}
+	if !strings.Contains(output, "stderr:\nnoisy error") {
+		t.Fatalf("Expected buffered stderr to be printed on failure, got: %s", output)
+	}
+}
+
+func TestCITaskModeIsInheritedByCalledTasks(t *testing.T) {
+	input := `
+version: 2.0
+
+task "lint":
+  run "echo inherited hidden output"
+
+task "ci" mode "ci":
+  call task "lint"
+`
+
+	var buf bytes.Buffer
+	if err := ExecuteString(input, "ci", &buf); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "inherited hidden output") {
+		t.Fatalf("Expected called task shell output to inherit ci buffering, got: %s", buf.String())
+	}
+}
+
+func TestRuntimeTaskModeOverrideDisablesCIBuffering(t *testing.T) {
+	input := `
+version: 2.0
+
+task "ci" mode "ci":
+  run "echo visible output"
+`
+
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("Parser errors: %v", p.Errors())
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngineWithOptions(WithOutput(&buf), WithTaskModeOverride("normal"))
+
+	if err := engine.Execute(program, "ci"); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "visible output") {
+		t.Fatalf("Expected runtime normal mode to disable ci buffering, got: %s", buf.String())
+	}
+}
+
+func TestRuntimeTaskModeOverrideEnablesCIBuffering(t *testing.T) {
+	input := `
+version: 2.0
+
+task "build":
+  run "echo hidden output"
+`
+
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("Parser errors: %v", p.Errors())
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngineWithOptions(WithOutput(&buf), WithTaskModeOverride("ci"))
+
+	if err := engine.Execute(program, "build"); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "hidden output") {
+		t.Fatalf("Expected runtime ci mode to buffer shell output, got: %s", buf.String())
+	}
+}
+
+func TestRuntimeTaskModeOverrideAppliesToCalledTasks(t *testing.T) {
+	input := `
+version: 2.0
+
+task "lint":
+  run "echo hidden called output"
+
+task "build":
+  call task "lint"
+`
+
+	l := lexer.NewLexer(input)
+	p := parser.NewParser(l)
+	program := p.ParseProgram()
+
+	if len(p.Errors()) > 0 {
+		t.Fatalf("Parser errors: %v", p.Errors())
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngineWithOptions(WithOutput(&buf), WithTaskModeOverride("ci"))
+
+	if err := engine.Execute(program, "build"); err != nil {
+		t.Fatalf("Execution failed: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "hidden called output") {
+		t.Fatalf("Expected runtime ci mode to propagate to called tasks, got: %s", buf.String())
 	}
 }
 

--- a/internal/parser/README.md
+++ b/internal/parser/README.md
@@ -84,7 +84,7 @@ Expression parsing:
 #### `parser_action.go` - 105 lines
 Action statements and task calls:
 - **Action statements** (`info`, `step`, `success`, `warning`, `error`)
-- **Task call statements** (`call task-name`)
+- **Task call statements** (`call task-name`, `call task "name" with iterations=100`)
 
 #### `parser_shell.go` - 175 lines
 Shell command execution:

--- a/internal/parser/dashed_task_name_test.go
+++ b/internal/parser/dashed_task_name_test.go
@@ -77,3 +77,39 @@ task "dependent":
 		t.Fatalf("expected dependency name 'run-action', got %q", group.Dependencies[0].Name)
 	}
 }
+
+func TestParseTaskCallWithNumericParameter(t *testing.T) {
+	input := `version: 2.0
+
+task "fuzz":
+  requires $iterations
+  info "Iterations: {$iterations}"
+
+task "caller":
+  call task fuzz with iterations=100
+`
+
+	l := lexer.NewLexer(input)
+	p := NewParser(l)
+	program := p.ParseProgram()
+
+	checkParserErrors(t, p)
+
+	if len(program.Tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(program.Tasks))
+	}
+
+	caller := program.Tasks[1]
+	if len(caller.Body) == 0 {
+		t.Fatalf("expected caller task to have a body")
+	}
+
+	callStmt, ok := caller.Body[0].(*ast.TaskCallStatement)
+	if !ok {
+		t.Fatalf("expected first statement to be TaskCallStatement, got %T", caller.Body[0])
+	}
+
+	if got := callStmt.Parameters["iterations"]; got != "100" {
+		t.Fatalf("expected iterations parameter to be %q, got %q", "100", got)
+	}
+}

--- a/internal/parser/parser_action.go
+++ b/internal/parser/parser_action.go
@@ -105,9 +105,9 @@ func (p *Parser) parseTaskCallStatement() *ast.TaskCallStatement {
 				return nil
 			}
 
-			// Expect parameter value as string
-			if !p.expectPeek(lexer.STRING) {
-				p.addError("expected parameter value as string")
+			// Expect parameter value as string or number
+			if !p.expectPeekOneOf(lexer.STRING, lexer.NUMBER) {
+				p.addError("expected parameter value as string or number")
 				return nil
 			}
 

--- a/internal/parser/parser_helpers.go
+++ b/internal/parser/parser_helpers.go
@@ -284,6 +284,29 @@ func (p *Parser) expectPeek(t lexer.TokenType) bool {
 	}
 }
 
+// expectPeekOneOf checks the peek token against several allowed types and advances if one matches.
+func (p *Parser) expectPeekOneOf(types ...lexer.TokenType) bool {
+	for _, t := range types {
+		if p.peekToken.Type == t {
+			p.nextToken()
+			return true
+		}
+	}
+
+	expected := make([]string, 0, len(types))
+	for _, t := range types {
+		expected = append(expected, t.String())
+	}
+
+	msg := fmt.Sprintf("expected next token to be one of [%s], got %s instead", strings.Join(expected, ", "), p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+	if p.errorList != nil {
+		p.errorList.Add(msg, p.peekToken)
+	}
+
+	return false
+}
+
 // expectPeekSkipNewlines expects a token type but skips any NEWLINE tokens first
 func (p *Parser) expectPeekSkipNewlines(t lexer.TokenType) bool {
 	// Skip any NEWLINE tokens

--- a/internal/parser/parser_task.go
+++ b/internal/parser/parser_task.go
@@ -23,6 +23,15 @@ func (p *Parser) parseTaskStatement() *ast.TaskStatement {
 
 	stmt.Name = p.curToken.Literal
 
+	// Check for optional task mode clause
+	if p.peekToken.Type == lexer.IDENT && p.peekToken.Literal == "mode" {
+		p.nextToken() // consume mode
+		if !p.expectPeek(lexer.STRING) {
+			return nil
+		}
+		stmt.Mode = p.curToken.Literal
+	}
+
 	// Check for optional "means" clause
 	if p.peekToken.Type == lexer.MEANS {
 		p.nextToken() // consume lexer.MEANS

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -131,6 +131,36 @@ task "greet" means "Greet someone by name":
 	}
 }
 
+func TestParser_TaskWithMode(t *testing.T) {
+	input := `version: 2.0
+
+task "ci" mode "ci" means "Runs buffered CI checks":
+  run "echo ok"`
+
+	lexer := lexer.NewLexer(input)
+	parser := NewParser(lexer)
+	program := parser.ParseProgram()
+
+	checkParserErrors(t, parser)
+
+	if len(program.Tasks) != 1 {
+		t.Fatalf("program.Tasks does not contain 1 task. got=%d", len(program.Tasks))
+	}
+
+	task := program.Tasks[0]
+	if task.Name != "ci" {
+		t.Errorf("task.Name wrong. expected=ci, got=%s", task.Name)
+	}
+
+	if task.Mode != "ci" {
+		t.Errorf("task.Mode wrong. expected=ci, got=%s", task.Mode)
+	}
+
+	if task.Description != "Runs buffered CI checks" {
+		t.Errorf("task.Description wrong. expected='Runs buffered CI checks', got=%s", task.Description)
+	}
+}
+
 func TestParser_BasicVersion(t *testing.T) {
 	input := `version: 2.0`
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -228,10 +228,26 @@ func Execute(command string, opts *Options) (*Result, error) {
 
 	// Check if we should treat this as an error
 	if !result.Success && !opts.IgnoreErrors {
-		return result, fmt.Errorf("command failed with exit code %d: %s", result.ExitCode, result.Stderr)
+		return result, fmt.Errorf("command failed with exit code %d%s", result.ExitCode, formatFailureOutput(result))
 	}
 
 	return result, nil
+}
+
+func formatFailureOutput(result *Result) string {
+	stdout := strings.TrimSpace(result.Stdout)
+	stderr := strings.TrimSpace(result.Stderr)
+
+	switch {
+	case stdout != "" && stderr != "":
+		return fmt.Sprintf(" (stdout: %s; stderr: %s)", stdout, stderr)
+	case stderr != "":
+		return fmt.Sprintf(": %s", stderr)
+	case stdout != "":
+		return fmt.Sprintf(": %s", stdout)
+	default:
+		return ""
+	}
 }
 
 func buildCommand(ctx context.Context, command string, opts *Options) *exec.Cmd {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -74,6 +74,60 @@ func TestExecute_Failure(t *testing.T) {
 	}
 }
 
+func TestExecute_FailureIncludesStdoutWhenStderrEmpty(t *testing.T) {
+	opts := DefaultOptions()
+	opts.CaptureOutput = true
+
+	var cmd string
+	if usesPowerShell(opts.Shell) {
+		cmd = "Write-Output 'gosec finding details'; exit 1"
+	} else {
+		cmd = "echo 'gosec finding details'; exit 1"
+	}
+
+	result, err := Execute(cmd, opts)
+	if err == nil {
+		t.Fatal("Expected Execute to return an error")
+	}
+
+	if result == nil {
+		t.Fatal("Expected Execute to return a result")
+	}
+
+	if !strings.Contains(err.Error(), "gosec finding details") {
+		t.Fatalf("Expected error to include stdout details, got %q", err.Error())
+	}
+}
+
+func TestExecute_FailureIncludesBothStdoutAndStderr(t *testing.T) {
+	opts := DefaultOptions()
+	opts.CaptureOutput = true
+
+	var cmd string
+	if usesPowerShell(opts.Shell) {
+		cmd = "Write-Output 'finding summary'; [Console]::Error.WriteLine('stack trace'); exit 1"
+	} else {
+		cmd = "echo 'finding summary'; echo 'stack trace' >&2; exit 1"
+	}
+
+	result, err := Execute(cmd, opts)
+	if err == nil {
+		t.Fatal("Expected Execute to return an error")
+	}
+
+	if result == nil {
+		t.Fatal("Expected Execute to return a result")
+	}
+
+	errText := err.Error()
+	if !strings.Contains(errText, "stdout: finding summary") {
+		t.Fatalf("Expected error to label stdout details, got %q", errText)
+	}
+	if !strings.Contains(errText, "stderr: stack trace") {
+		t.Fatalf("Expected error to label stderr details, got %q", errText)
+	}
+}
+
 func TestExecute_WithEnvironment(t *testing.T) {
 	opts := DefaultOptions()
 	opts.CaptureOutput = true

--- a/scripts/fuzz-examples.sh
+++ b/scripts/fuzz-examples.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ITERATIONS="${1:-50}"
+
+if ! [[ "${ITERATIONS}" =~ ^[0-9]+$ ]] || [ "${ITERATIONS}" -le 0 ]; then
+    echo "usage: $0 [positive-iteration-count]" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+echo -e "${BLUE}==${NC} Building xdrun for fuzzing"
+mkdir -p bin
+go build -o bin/xdrun ./cmd/xdrun
+
+CORPUS=()
+while IFS= read -r file; do
+    CORPUS+=("${file}")
+done < <(find examples -maxdepth 1 -type f -name '*.drun' | sort)
+if [ "${#CORPUS[@]}" -eq 0 ]; then
+    echo -e "${RED}No example corpus found under examples/${NC}" >&2
+    exit 1
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/drun-fuzz.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+TOTAL=0
+PARSE_OK=0
+PARSE_FAIL=0
+DRY_RUN_OK=0
+DRY_RUN_SKIP=0
+CRASHES=0
+
+extract_first_task() {
+    local list_file="$1"
+    grep -E "^  " "${list_file}" | head -1 | sed 's/^  //' | sed -E 's/  +.*//' | xargs
+}
+
+try_dry_run() {
+    local spec_file="$1"
+    local task_name="$2"
+    local output_file="$3"
+
+    local param_attempts=(
+        ""
+        "name=test"
+        "environment=dev"
+        "items=test1,test2"
+        "source_path=/tmp/test"
+        "name=test environment=dev"
+        "name=test title=friend"
+        "app_name=myapp namespace=default"
+    )
+
+    local params
+    for params in "${param_attempts[@]}"; do
+        if [ -n "${params}" ]; then
+            # shellcheck disable=SC2086
+            if ./bin/xdrun -f "${spec_file}" "${task_name}" ${params} --dry-run >"${output_file}" 2>&1; then
+                return 0
+            fi
+        else
+            if ./bin/xdrun -f "${spec_file}" "${task_name}" --dry-run >"${output_file}" 2>&1; then
+                return 0
+            fi
+        fi
+    done
+
+    return 1
+}
+
+append_generated_task() {
+    local target="$1"
+    local iteration="$2"
+    cat >> "${target}" <<EOF
+
+task "fuzz generated ${iteration}" means "Generated local fuzz case":
+    info "Generated from the example corpus"
+    step "iteration ${iteration}"
+    run "echo fuzz-${iteration}"
+EOF
+}
+
+mutate_case() {
+    local source_file="$1"
+    local target_file="$2"
+    local iteration="$3"
+
+    cp "${source_file}" "${target_file}"
+
+    local passes=$((1 + RANDOM % 3))
+    local pass
+    for ((pass = 0; pass < passes; pass++)); do
+        case $((RANDOM % 8)) in
+            0)
+                perl -0pi -e 's/\binfo\b/step/' "${target_file}"
+                ;;
+            1)
+                perl -0pi -e 's/\bstep\b/info/' "${target_file}"
+                ;;
+            2)
+                perl -0pi -e 's/task "([^"]+)":/task "$1 fuzzed":/' "${target_file}"
+                ;;
+            3)
+                perl -0pi -e 's/version: 2\.0/version: 2.0\n\n# fuzzed input/' "${target_file}"
+                ;;
+            4)
+                perl -0pi -e 's/"([^"]+)"/"$1 fuzz"/' "${target_file}"
+                ;;
+            5)
+                append_generated_task "${target_file}" "${iteration}"
+                ;;
+            6)
+                printf '\n# fuzz-note-%s\n' "${iteration}" >> "${target_file}"
+                ;;
+            7)
+                perl -0pi -e 's/\brun\b/info/' "${target_file}"
+                ;;
+        esac
+    done
+
+    if [ $((RANDOM % 5)) -eq 0 ]; then
+        case $((RANDOM % 3)) in
+            0)
+                perl -0pi -e 's/:\n/\n/' "${target_file}"
+                ;;
+            1)
+                perl -0pi -e 's/task "([^"]+)":/task $1:/' "${target_file}"
+                ;;
+            2)
+                perl -0pi -e 's/"([^"]+)"/"$1/' "${target_file}"
+                ;;
+        esac
+    fi
+}
+
+echo -e "${BLUE}==${NC} Running ${ITERATIONS} semantic fuzz iterations"
+
+for ((i = 1; i <= ITERATIONS; i++)); do
+    TOTAL=$((TOTAL + 1))
+    SOURCE_FILE="${CORPUS[RANDOM % ${#CORPUS[@]}]}"
+    CASE_FILE="${TMP_ROOT}/case-${i}.drun"
+    LIST_OUTPUT="${TMP_ROOT}/case-${i}.list.log"
+    DRY_OUTPUT="${TMP_ROOT}/case-${i}.dry.log"
+
+    mutate_case "${SOURCE_FILE}" "${CASE_FILE}" "${i}"
+
+    ./bin/xdrun -f "${CASE_FILE}" -l >"${LIST_OUTPUT}" 2>&1
+    status=$?
+
+    if [ "${status}" -eq 0 ]; then
+        PARSE_OK=$((PARSE_OK + 1))
+        FIRST_TASK="$(extract_first_task "${LIST_OUTPUT}")"
+
+        if [ -n "${FIRST_TASK}" ] && try_dry_run "${CASE_FILE}" "${FIRST_TASK}" "${DRY_OUTPUT}"; then
+            DRY_RUN_OK=$((DRY_RUN_OK + 1))
+            echo -e "${GREEN}PASS${NC} [${i}/${ITERATIONS}] $(basename "${SOURCE_FILE}") -> dry-run task '${FIRST_TASK}'"
+        else
+            DRY_RUN_SKIP=$((DRY_RUN_SKIP + 1))
+            echo -e "${YELLOW}SOFT${NC} [${i}/${ITERATIONS}] $(basename "${SOURCE_FILE}") parsed, but no runnable first task"
+        fi
+        continue
+    fi
+
+    if [ "${status}" -ge 128 ] || grep -Eq 'panic:|fatal error:' "${LIST_OUTPUT}"; then
+        CRASHES=$((CRASHES + 1))
+        echo -e "${RED}CRASH${NC} [${i}/${ITERATIONS}] $(basename "${SOURCE_FILE}")"
+        sed -n '1,80p' "${LIST_OUTPUT}"
+    else
+        PARSE_FAIL=$((PARSE_FAIL + 1))
+        echo -e "${BLUE}MISS${NC} [${i}/${ITERATIONS}] $(basename "${SOURCE_FILE}") rejected by parser"
+    fi
+done
+
+echo
+echo -e "${BLUE}==${NC} Fuzz summary"
+echo "iterations: ${TOTAL}"
+echo "parsed: ${PARSE_OK}"
+echo "rejected: ${PARSE_FAIL}"
+echo "dry-run validated: ${DRY_RUN_OK}"
+echo "parsed but not runnable: ${DRY_RUN_SKIP}"
+echo "crashes: ${CRASHES}"
+
+if [ "${PARSE_OK}" -eq 0 ]; then
+    echo -e "${RED}No mutated inputs parsed successfully. The generator is too destructive.${NC}" >&2
+    exit 1
+fi
+
+if [ "${CRASHES}" -ne 0 ]; then
+    echo -e "${RED}Fuzzing found ${CRASHES} crash(es).${NC}" >&2
+    exit 1
+fi
+
+echo -e "${GREEN}Semantic fuzzing completed without crashes.${NC}"


### PR DESCRIPTION
## Added:

### Task execution mode

Some outputs can be very verbose of garbage that isn't necessarily useful (until something really crashes).

For saving input tokens in Large Language Models, for example, and for saving log pressure in general, Drun now has the `mode` statement.

Current modes are:

- `normal` outputs unopinionated output, as is
  
- `ci` a more silent mode. Outputs the things from Drun itself, like `step`, `echo`, etc, but don't immediately outputs the buffer. The buffer is kept until the end of the execution. If the task fails, then, and only then, the buffer is dumped.
  

This saves quite a lot of log pressure.

By default all tasks assume the normal mode implicitly.

Example usage:

```drun
task "test" mode "ci" means "Runs a very verbose test suite":
    step "This part will show"
    # This part will not, except if it fails
    run "./humungusscript.sh"
```

Of course, one can override this. On the CLI, one now can run:

```bash
xdrun test --task-mode=normal
```

One can also run a normal task in CI mode.

## Updated

- Drun banners now point to the proper repo
  
- Added a semantic fuzzer, for feeding the interpreter tons of garbage and seeing if it panics.
  
- Test coverage: made sure the initialization of new specs have test coverage
  
- New specs:
  
  - Added a minimal mode for creating a single drun task
    
  - Drun now attempts to figure out a name for the project based on the name of the PWD where the project was created
    
- Pipelines: Added the fuzzer to the release pipeline lifecycle
  

## Conclusion

All of these changes ate backwards compatible with `< v2.19` . However, the execution mode is a novel feature. Thus, according to our conventions, we should bump drun to v2.20.